### PR TITLE
Fix build on modern GHCs

### DIFF
--- a/Data/Conduit/IConv.hs
+++ b/Data/Conduit/IConv.hs
@@ -34,9 +34,9 @@ type CharacterEncoding = String
 -- Without this encoding errors will cause an exception.
 --
 -- On errors this will call `fail`
-convert :: Monad m => CharacterEncoding -- ^ Name of input character encoding
-                   -> CharacterEncoding -- ^ Name of output character encoding
-                   -> Conduit B.ByteString m B.ByteString
+convert :: MonadFail m => CharacterEncoding -- ^ Name of input character encoding
+                       -> CharacterEncoding -- ^ Name of output character encoding
+                       -> Conduit B.ByteString m B.ByteString
 convert inputEncoding outputEncoding = run initialConvert
   where
     initialConvert = iconvConvert inputEncoding outputEncoding

--- a/conduit-iconv.cabal
+++ b/conduit-iconv.cabal
@@ -1,5 +1,5 @@
 name:                  conduit-iconv
-version:               0.1.1.3
+version:               0.1.2.0
 synopsis:              Conduit for character encoding conversion.
 description:
     @conduit-iconv@ provides a Conduit for character encoding
@@ -17,7 +17,7 @@ library
   exposed-modules:     Data.Conduit.IConv
   build-depends:       base == 4.*
                      , conduit >= 1.1 && < 1.4
-                     , bytestring >= 0.10.4 && < 0.11
+                     , bytestring >= 0.10.4 && < 0.12
   default-language:    Haskell2010
   ghc-options:         -Wall
   includes:            iconv.h

--- a/tests/Tests.hs
+++ b/tests/Tests.hs
@@ -1,6 +1,9 @@
 module Main where
 
+import Data.Either
+
 import Control.Monad.Identity
+import Control.Monad.Error
 
 import qualified Data.ByteString as B
 import qualified Data.ByteString.Char8 as BC
@@ -81,8 +84,8 @@ prop_identity ::    (String -> BC.ByteString)
 prop_identity encode encodeTo decode decodeTo inString n a b c d = inString == output
     where input = encode inString
           inputChunked = chunkByteString n a b c d input
-          converted = runIdentity $ CL.sourceList inputChunked $$ I.convert encodeTo decodeTo =$ CL.consume
-          output = decode . B.concat $ converted
+          converted = runIdentity $ runErrorT $ CL.sourceList inputChunked $$ I.convert encodeTo decodeTo =$ CL.consume
+          output = decode . B.concat $ either error id converted
 
 main :: IO ()
 main = defaultMain tests


### PR DESCRIPTION
This is a minimal amount of fixes to get this built and tested on modern GHCs. I deliberately don't fix any warnings, and on contrary, use deprecated `Control.Monad.Error` to make the tests fix as simple as possible.